### PR TITLE
Ubuntu arm64

### DIFF
--- a/.github/workflows/condabuild.yml
+++ b/.github/workflows/condabuild.yml
@@ -61,7 +61,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: "${{ matrix.os }}"
-          path: "${{ steps.condablddir.outputs.condabld }}/*/bioformats2raw-*.tar.bz2"
+          path: "${{ steps.condablddir.outputs.condabld }}/*/bioformats2raw-*.conda"
           if-no-files-found: error
 
   upload:

--- a/.github/workflows/condabuild.yml
+++ b/.github/workflows/condabuild.yml
@@ -10,6 +10,7 @@ jobs:
     strategy:
       matrix:
         os:
+          - ubuntu-24.04-arm
           - macos-12
           - macos-14
           - ubuntu-latest

--- a/.github/workflows/condabuild.yml
+++ b/.github/workflows/condabuild.yml
@@ -24,6 +24,7 @@ jobs:
           auto-activate-base: true
           activate-environment: ""
           miniconda-version: "latest"
+          python-version: 3.12
 
       - name: Set conda-bld output folder to make it easier to find artifacts
         id: condablddir


### PR DESCRIPTION
Hello,
I would like to add a package for Linux with arm64 architecture. My end goal is to build a Docker image to use on a cluster with this processor architecture (so it's a requirement afaik).

I am changing only the CI here because I found several errors (not just with the target I added `ubuntu-24.04-arm`).

<details>

<summary>First error with conda-verify, fixed by setting the python version to 3.12:</summary>

```
Run conda install -y -q conda-build conda-verify
CI detected...
By accessing https://repo.anaconda.com/pkgs/main via CI for this repository you 
acknowledge and agree to the Terms of Service:
ANACONDA TERMS OF SERVICE
Effective Date: July 15, 2025

See https://anaconda.com/legal/terms/terms-of-service
By accessing https://repo.anaconda.com/pkgs/r via CI for this repository you 
acknowledge and agree to the Terms of Service:
ANACONDA TERMS OF SERVICE
Effective Date: July 15, 2025

See https://anaconda.com/legal/terms/terms-of-service
2 channel Terms of Service accepted
Retrieving notices: ...working... done
Channels:
 - defaults
Platform: linux-aarch64
Collecting package metadata (repodata.json): ...working... done
Solving environment: ...working... failed

LibMambaUnsatisfiableError: Encountered problems while solving:
  - package conda-verify-3.4.2-py_0 requires future, but none of the providers can be installed

Could not solve for environment specs
The following packages are incompatible
├─ conda-verify =* * is installable and it requires
│  └─ future =* * with the potential options
│     ├─ future [0.18.2|0.18.3|1.0.0] would require
│     │  └─ python >=3.10,<3.11.0a0 *, which can be installed;
│     ├─ future [0.18.2|0.18.3|1.0.0] would require
│     │  └─ python >=3.11,<3.12.0a0 *, which can be installed;
│     ├─ future [0.18.2|0.18.3] would require
│     │  └─ python >=3.7,<3.8.0a0 *, which can be installed;
│     ├─ future [0.18.2|0.18.3] would require
│     │  └─ python >=3.8,<3.9.0a0 *, which can be installed;
│     ├─ future [0.18.2|0.18.3|1.0.0] would require
│     │  └─ python >=3.9,<3.10.0a0 *, which can be installed;
│     └─ future [0.18.3|1.0.0] would require
│        └─ python >=3.12,<3.13.0a0 *, which can be installed;
└─ pin on python =3.13 * is not installable because it requires
   └─ python =3.13 *, which conflicts with any installable versions previously reported.

Pins seem to be involved in the conflict. Currently pinned specs:
 - python=3.13


Error: Process completed with exit code 1.
```
</details>

<details>

<summary>Second error, the extension of the built package changed to .conda</summary>

```
Run ls -R "/Users/runner/conda-bld"
channeldata.json
index.html
noarch
osx-arm64

/Users/runner/conda-bld/noarch:
current_repodata.json
index.html
repodata.json
repodata_from_packages.json

/Users/runner/conda-bld/osx-arm64:
bioformats2raw-0.9.4-0.conda           ← ← ← ← ← ← ← ← ← ← ← ← ← ← ←
current_repodata.json
index.html
repodata.json
repodata_from_packages.json


Run actions/upload-artifact@v4
Error: No files were found with the provided path: /Users/runner/conda-bld/*/bioformats2raw-*.tar.bz2. No artifacts will be uploaded.
```
</details>

In my CI testing, I also saw that the build jobs for `macos-12` where hanging forever waiting for a worker to take the job.
Should I remove it and add the change to this PR?

When this is approved I'd like to bump bioformats2raw version in `meta.yaml`. 
If I bump directly to the latest bioformats2raw-0.11.0, then version 10.0 and 10.1 would be skipped. 
Is that ok or do you want to make each of those?