### PR TITLE
Ubuntu arm package build

### DIFF
--- a/.github/workflows/condabuild.yml
+++ b/.github/workflows/condabuild.yml
@@ -10,7 +10,6 @@ jobs:
     strategy:
       matrix:
         os:
-          - macos-12
           - macos-14
           - ubuntu-latest
           - windows-latest

--- a/.github/workflows/condabuild.yml
+++ b/.github/workflows/condabuild.yml
@@ -12,6 +12,7 @@ jobs:
         os:
           - macos-latest
           - ubuntu-latest
+          - ubuntu-24.04-arm
           - windows-latest
       fail-fast: false
 

--- a/.github/workflows/condabuild.yml
+++ b/.github/workflows/condabuild.yml
@@ -51,7 +51,7 @@ jobs:
         run: conda install -y -q conda-build conda-verify
 
       - name: Build packages
-        run: conda build .
+        run: conda build . --package-format tar.bz2
 
       - run: ls -R "${{ steps.condablddir.outputs.condabld }}"
 

--- a/.github/workflows/condabuild.yml
+++ b/.github/workflows/condabuild.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - macos-14
+          - macos-latest
           - ubuntu-latest
           - windows-latest
       fail-fast: false

--- a/.github/workflows/condabuild.yml
+++ b/.github/workflows/condabuild.yml
@@ -22,6 +22,7 @@ jobs:
           auto-activate-base: true
           activate-environment: ""
           miniconda-version: "latest"
+          python-version: "3.12"
 
       - name: Set conda-bld output folder to make it easier to find artifacts
         id: condablddir

--- a/.github/workflows/condabuild.yml
+++ b/.github/workflows/condabuild.yml
@@ -32,7 +32,7 @@ jobs:
             echo "condabld=c:\\conda-bld" >> $GITHUB_OUTPUT
           else
             echo "condabld=$HOME/conda-bld" >> $GITHUB_OUTPUT
-            if [ ${{ matrix.os }} = macos-14 ]; then
+            if [ ${{ matrix.os }} = macos-latest ]; then
               # Surprising that this is required. Locally, the directory includes "arm" automatically
               conda config --env --set subdir "osx-arm64"
             fi


### PR DESCRIPTION
Hello,
I would like to add a package for Linux with arm64 architecture. My end goal is to build a Docker image to use on a cluster with this processor architecture (so it's a requirement afaik).

I added a fix for the CI, an error with conda-verify, fixed by setting the python version to 3.12

<details>

<summary>The error</summary>

```
Run conda install -y -q conda-build conda-verify

LibMambaUnsatisfiableError: Encountered problems while solving:
  - package conda-verify-3.4.2-py_0 requires future, but none of the providers can be installed

Could not solve for environment specs
The following packages are incompatible
├─ conda-verify =* * is installable and it requires
│  └─ future =* * with the potential options
│     ├─ future [0.18.2|0.18.3|1.0.0] would require
│     │  └─ python >=3.10,<3.11.0a0 *, which can be installed;
│     ├─ future [0.18.2|0.18.3|1.0.0] would require
│     │  └─ python >=3.11,<3.12.0a0 *, which can be installed;
│     ├─ future [0.18.2|0.18.3] would require
│     │  └─ python >=3.7,<3.8.0a0 *, which can be installed;
│     ├─ future [0.18.2|0.18.3] would require
│     │  └─ python >=3.8,<3.9.0a0 *, which can be installed;
│     ├─ future [0.18.2|0.18.3|1.0.0] would require
│     │  └─ python >=3.9,<3.10.0a0 *, which can be installed;
│     └─ future [0.18.3|1.0.0] would require
│        └─ python >=3.12,<3.13.0a0 *, which can be installed;
└─ pin on python =3.13 * is not installable because it requires
   └─ python =3.13 *, which conflicts with any installable versions previously reported.

Pins seem to be involved in the conflict. Currently pinned specs:
 - python=3.13


Error: Process completed with exit code 1.
```
</details>


When this is approved I'd like to bump bioformats2raw version in meta.yaml.
If I bump directly to the latest bioformats2raw-0.11.0, then version 10.0 and 10.1 would be skipped.
Is that ok or do you want to build the intermediary versions?

Edit for more context:
* commits from @jburel are from [his PR](https://github.com/ome/conda-bioformats2raw/pull/26) that I used as working branch, since it had fixes for issues I also saw.
* installing bioformats2raw with conda is the easy way. But for ARM64 architecture this is the only way I found. I've struggled several days with libblosc dependency and couldn't solve it in the docker container I tried to make. But to install with conda for that architecture we need that specific build. Hence this PR
* The action of this PR generated the package that I could test install in a docker container with ARM64 architecture. 

Testing:
* from the action [build (ubuntu-24.04-arm)](https://github.com/ome/conda-bioformats2raw/actions/runs/23840419793/job/69494344692#logs) download the "Artifact download URL" in `Run actions/upload-artifact@v4` → currently https://github.com/ome/conda-bioformats2raw/actions/runs/23840419793/artifacts/6216831992  (still works today, if not in the future, re-run the action)
* To test with bioformats2raw-docker, Use the branch https://github.com/Tom-TBT/bioformats2raw-docker/tree/test_arm64
* place the artifact inside bioformats2raw-docker
* build the docker image for ARM64: `docker build -t bf2r_arm64_test --platform linux/arm64 .`
* test the image: `docker run --rm -v "$(pwd):/data" bf2r_arm64_test /data/image.tif /data/image.zarr`