### PR TITLE
Bump bioformats2raw to 0.10.1

### DIFF
--- a/meta.yaml
+++ b/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "bioformats2raw" %}
-{% set version = "0.9.4" %}
+{% set version = "0.10.0" %}
 
 package:
   name: "{{ name|lower }}"
@@ -11,7 +11,7 @@ build:
 source:
   url: https://github.com/glencoesoftware/{{ name }}/releases/download/v{{ version
     }}/{{ name }}-{{ version }}.zip
-  sha256: 855e13599df9643f8abdc861e7bada1f3e4e32cc519f684036b9581819eb9319
+  sha256: b9a3d4d046a8ac7973cd2a23efd1c6f801ff865485acd624d69a23ae595dfc6b
 
 requirements:
   run:

--- a/meta.yaml
+++ b/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "bioformats2raw" %}
-{% set version = "0.10.0" %}
+{% set version = "0.10.1" %}
 
 package:
   name: "{{ name|lower }}"
@@ -11,7 +11,7 @@ build:
 source:
   url: https://github.com/glencoesoftware/{{ name }}/releases/download/v{{ version
     }}/{{ name }}-{{ version }}.zip
-  sha256: b9a3d4d046a8ac7973cd2a23efd1c6f801ff865485acd624d69a23ae595dfc6b
+  sha256: db1e47b103056220eeab7be705e3d41e3ed74e80f5fd3b86975fa01c77680502
 
 requirements:
   run:


### PR DESCRIPTION
I'm opening PRs for all missing builds up to the current latest bioformats2raw (0.12.1):
* 0.10.0 → https://github.com/ome/conda-bioformats2raw/pull/30
* 0.10.1 → this one
* 0.11.0 → https://github.com/ome/conda-bioformats2raw/pull/32
* 0.12.0 → https://github.com/ome/conda-bioformats2raw/pull/33
* 0.12.1 → https://github.com/ome/conda-bioformats2raw/pull/34

Just like 0.10.0, it includes build for ARM64 as bioformats2raw 0.10.1 still depends on jzarr.