### PR TITLE
Bump bioformats2raw to 0.12.0

### DIFF
--- a/.github/workflows/condabuild.yml
+++ b/.github/workflows/condabuild.yml
@@ -12,7 +12,7 @@ jobs:
         os:
           - macos-latest
           - ubuntu-latest
-          - ubuntu-24.04-arm
+          # - ubuntu-24.04-arm
           - windows-latest
       fail-fast: false
 

--- a/meta.yaml
+++ b/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "bioformats2raw" %}
-{% set version = "0.11.0" %}
+{% set version = "0.12.0" %}
 
 package:
   name: "{{ name|lower }}"
@@ -11,7 +11,7 @@ build:
 source:
   url: https://github.com/glencoesoftware/{{ name }}/releases/download/v{{ version
     }}/{{ name }}-{{ version }}.zip
-  sha256: ea5352eb684ed989622559e2cd594077ce5f58b6fe375ede08518856622a3864
+  sha256: 82964c3e2e4b5f27e3bafbd7fdca2afe4570f44863d2363f7d0ba2a23b9d39e3
 
 requirements:
   run:

--- a/meta.yaml
+++ b/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "bioformats2raw" %}
-{% set version = "0.9.4" %}
+{% set version = "0.10.0" %}
 
 package:
   name: "{{ name|lower }}"
@@ -11,7 +11,7 @@ build:
 source:
   url: https://github.com/glencoesoftware/{{ name }}/releases/download/v{{ version
     }}/{{ name }}-{{ version }}.zip
-  sha256: 855e13599df9643f8abdc861e7bada1f3e4e32cc519f684036b9581819eb9319
+  sha256: b9a3d4d046a8ac7973cd2a23efd1c6f801ff865485acd624d69a23ae595dfc6b
 
 requirements:
   run:

--- a/meta.yaml
+++ b/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "bioformats2raw" %}
-{% set version = "0.10.0" %}
+{% set version = "0.10.1" %}
 
 package:
   name: "{{ name|lower }}"
@@ -11,7 +11,7 @@ build:
 source:
   url: https://github.com/glencoesoftware/{{ name }}/releases/download/v{{ version
     }}/{{ name }}-{{ version }}.zip
-  sha256: b9a3d4d046a8ac7973cd2a23efd1c6f801ff865485acd624d69a23ae595dfc6b
+  sha256: db1e47b103056220eeab7be705e3d41e3ed74e80f5fd3b86975fa01c77680502
 
 requirements:
   run:

--- a/meta.yaml
+++ b/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "bioformats2raw" %}
-{% set version = "0.10.1" %}
+{% set version = "0.11.0" %}
 
 package:
   name: "{{ name|lower }}"
@@ -11,7 +11,7 @@ build:
 source:
   url: https://github.com/glencoesoftware/{{ name }}/releases/download/v{{ version
     }}/{{ name }}-{{ version }}.zip
-  sha256: db1e47b103056220eeab7be705e3d41e3ed74e80f5fd3b86975fa01c77680502
+  sha256: ea5352eb684ed989622559e2cd594077ce5f58b6fe375ede08518856622a3864
 
 requirements:
   run:


### PR DESCRIPTION
I'm opening PRs for all missing builds up to the current latest bioformats2raw (0.12.1):
* 0.10.0 → https://github.com/ome/conda-bioformats2raw/pull/30
* 0.10.1 → https://github.com/ome/conda-bioformats2raw/pull/31
* 0.11.0 → https://github.com/ome/conda-bioformats2raw/pull/32
* 0.12.0 → this one
* 0.12.1 → https://github.com/ome/conda-bioformats2raw/pull/34

For this version, I skipped the build for ARM64 architecture in the github action (comes back with 0.12.1)
The dependency for jzarr changed to zarr-java, which uses https://github.com/scalableminds/blosc-java and had no c-blosc build for linux ARM64.

The next version of bioformats2raw (0.12.1) depends on zarr-java 0.1.3 which now includes c-blosc library for ARM64.